### PR TITLE
Added expose_php and date.timezone to php.ini

### DIFF
--- a/conf.d/php.ini
+++ b/conf.d/php.ini
@@ -3,3 +3,5 @@ memory_limit=64M
 upload_max_filesize=64M
 post_max_size=64M
 max_execution_time=600
+expose_php=Off
+;date.timezone=UTC


### PR DESCRIPTION
1) Hide the PHP version to increase WordPress security.
2) It may help to set the timezone as well.